### PR TITLE
NextGens duplication fixed

### DIFF
--- a/Hooks/NextGens/src/main/java/com/bgsoftware/common/shopsbridge/ShopsBridge_NextGens.java
+++ b/Hooks/NextGens/src/main/java/com/bgsoftware/common/shopsbridge/ShopsBridge_NextGens.java
@@ -27,9 +27,8 @@ public class ShopsBridge_NextGens implements PricesAccessorNoTransactions, IShop
 
     @Override
     public BigDecimal getSellPriceInternal(ItemStack itemStack) {
-        BigDecimal price = Optional.ofNullable(NextGens.getApi().getWorth(itemStack))
-                .map(BigDecimal::valueOf).orElse(null);
-        return price == null ? BigDecimal.ZERO : price;
+        return Optional.ofNullable(NextGens.getApi().getWorth(itemStack))
+                .map(BigDecimal::valueOf).orElse(BigDecimal.ZERO);
     }
 
     @Override

--- a/Hooks/NextGens/src/main/java/com/bgsoftware/common/shopsbridge/ShopsBridge_NextGens.java
+++ b/Hooks/NextGens/src/main/java/com/bgsoftware/common/shopsbridge/ShopsBridge_NextGens.java
@@ -29,8 +29,7 @@ public class ShopsBridge_NextGens implements PricesAccessorNoTransactions, IShop
     public BigDecimal getSellPriceInternal(ItemStack itemStack) {
         BigDecimal price = Optional.ofNullable(NextGens.getApi().getWorth(itemStack))
                 .map(BigDecimal::valueOf).orElse(null);
-        return price == null ? BigDecimal.ZERO : itemStack.getAmount() <= 1 ? price :
-                price.multiply(BigDecimal.valueOf(itemStack.getAmount()));
+        return price == null ? BigDecimal.ZERO : price;
     }
 
     @Override


### PR DESCRIPTION
NextGens directly returns the desired number of items to calculate the price for, so there's no need for multiplication, it causes a dupe.